### PR TITLE
feat: return all NIP-05 mappings when no name parameter is provided

### DIFF
--- a/internal_services.jl
+++ b/internal_services.jl
@@ -713,6 +713,12 @@ function nostr_json_handler(req::HTTP.Request)
             if !isempty(local pks = nostr_json_query_by_name(name))
                 nj = Dict([name=>pks[1]])
             end
+        else
+            lock(nostr_json_query_lock) do
+                for (name, pk) in DB.exec(verified_users[], DB.@sql("select name, pubkey from verified_users"))
+                    nj[name] = Nostr.PubKeyId(pk)
+                end
+            end
         end
         HTTP.Response(200, HTTP.Headers(["Content-Type"=>"application/json"]), JSON.json((; names=nj), 2))
     end


### PR DESCRIPTION
Problem: there is no way to display a feed of all Primal users using pure client-side solutions:

<img width="865" height="587" alt="image" src="https://github.com/user-attachments/assets/b6652994-88a6-4e84-9787-52f7bf44c4c3" />

https://jumble.social/notes?d=primal.net

Compare to this:

<img width="865" height="587" alt="image" src="https://github.com/user-attachments/assets/5738d44a-c3e0-4648-a7f2-ca9a1f69ff28" />

https://jumble.social/notes?d=spinster-xyz.mostr.pub

This change enables a Primal-only NIP-05 feed to be displayed.